### PR TITLE
Added definition stdlib::shellvar for shellvar manipulation.

### DIFF
--- a/manifests/shellvar.pp
+++ b/manifests/shellvar.pp
@@ -1,0 +1,91 @@
+# == Definition: stdlib::shellvar
+#
+# Manipulates shell variables in files (typically the contents
+# of /etc/sysconfig/* or /etc/default/*).
+#
+# === Parameters:
+#
+# [*file*] The file containing the shell variables. This should
+#          be an absolute path.
+#          - Required: yes
+#          - Type: String
+#
+# [*key*] The variable to manipulate.
+#              - Required: yes
+#              - Type: String
+#
+# [*value*] The value to be assigned to the key.
+#           - Required: no
+#           - Default: ''
+#           - Type: String
+#
+# [*ensure*] The desired state for the key/value pair. A value of
+#            absent removes the shell variable from the file, a
+#            declaration of stdlib::shellvar without the optional
+#            parameters creates an empty shell variable.
+#            - Required: no
+#            - Default: present
+#            - Content: present | absent
+#
+# === Sample Usage:
+#
+# Adding an extra shell-type key/value pair:
+#
+#   stdlib::shellvar { 'Puppet agent log':
+#     file  => '/etc/sysconfig/puppet',
+#     key   => 'PUPPET_LOG',
+#     value => '/var/log/puppet/puppet.log'
+#   }
+#
+# Removing a shell-type key/value pair:
+#
+#   stdlib::shellvar { 'Remove grub forcelba':
+#     file   => '/etc/sysconfig/grub',
+#     key    => 'forcelba',
+#     ensure => absent
+#   }
+#
+# Clearing the value of a shell-type key/value pair:
+#
+#   stdlib::shellvar { 'Clear extra iptables modules':
+#     file   => '/etc/sysconfig/iptables-config',
+#     key    => 'IPTABLES_MODULES'
+#   }
+#
+define stdlib::shellvar(
+                          $file,
+                          $key,
+                          $value = '',
+                          $ensure = present
+                        ) {
+  if $file !~ /^\/.*$/ {
+    fail("Stdlib::Shellvar[${title}]: parameter file must be an absolute path")
+  }
+
+  case $ensure {
+    present:
+      {
+        augeas { $title :
+          lens    => 'Shellvars.lns',
+          incl    => $file,
+          context => "/files${file}",
+          onlyif  => "get ${key} != '${value}'",
+          changes => ["set ${key} '${value}'" ]
+        }
+      }
+    absent:
+      {
+        augeas { $title :
+          lens    => 'Shellvars.lns',
+          incl    => $file,
+          context => "/files${file}",
+          onlyif  => "match ${key} size > 0",
+          changes => [ "rm ${key}" ]
+        }
+      }
+    default:
+      {
+        fail("Stdlib::Shellvar[${title}]: parameter ensure must be present or absent")
+      }
+  }
+}

--- a/spec/defines/stdlib_shellvar_spec.rb
+++ b/spec/defines/stdlib_shellvar_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+describe 'stdlib::shellvar', :type => :define do
+  let(:title) { 'test' }
+
+  context 'with file => \'conf/test.properties\'' do
+    let(:params) {
+      {
+        :file => 'conf/test.properties',
+        :key  => 'bar'
+      }
+    }
+
+    it {
+      expect { subject }.to raise_error(
+        Puppet::Error, /parameter file must be an absolute path/
+      )
+    }
+  end
+
+  context 'with ensure => installed' do
+    let(:params) {
+      {
+        :file   => '/tmp/foo',
+        :key    => 'bar',
+        :ensure => 'installed'
+      }
+    }
+
+    it {
+      expect { subject }.to raise_error(
+        Puppet::Error, /parameter ensure must be present or absent/
+      )
+    }
+  end
+
+  context 'with ensure => absent' do
+    let(:params) {
+      {
+        :file   => '/tmp/foo',
+        :key    => 'bar',
+        :ensure => 'absent'
+      }
+    }
+
+    it {
+      should contain_augeas('test').with(
+        {
+          :lens    => 'Shellvars.lns',
+          :incl    => '/tmp/foo',
+          :context => '/files/tmp/foo',
+          :onlyif  => 'match bar size > 0',
+          :changes => [ 'rm bar' ]
+        }
+      )
+    }
+  end
+
+  context 'without optional parameters' do
+    let(:params) {
+      {
+        :file  => '/tmp/foo',
+        :key   => 'bar',
+      }
+    }
+
+    it {
+      should contain_augeas('test').with(
+        {
+          :lens    => 'Shellvars.lns',
+          :incl    => '/tmp/foo',
+          :context => '/files/tmp/foo',
+          :onlyif  => 'get bar != \'\'',
+          :changes => [ 'set bar \'\'' ]
+        }
+      )
+    }
+  end
+
+  context 'with value => \'baz\'' do
+    let(:params) {
+      {
+        :file  => '/tmp/foo',
+        :key   => 'bar',
+        :value => 'baz'
+      }
+    }
+
+    it {
+      should contain_augeas('test').with(
+        {
+          :lens    => 'Shellvars.lns',
+          :incl    => '/tmp/foo',
+          :context => '/files/tmp/foo',
+          :onlyif  => 'get bar != \'baz\'',
+          :changes => [ 'set bar \'baz\'' ]
+        }
+      )
+    }
+  end
+end


### PR DESCRIPTION
Manipulates shell variables in files (typically the contents of /etc/sysconfig/\* or /etc/default/*).
