### PR TITLE
[HIERA] Changed mysql backend to hold YAML files instead of raw hashes.

### DIFF
--- a/lib/hiera/backend/mysql_backend.rb
+++ b/lib/hiera/backend/mysql_backend.rb
@@ -10,7 +10,6 @@ class Hiera
                 begin
                   require 'mysql'
                   require 'yaml'
-                  require 'pp'
                 rescue LoadError
                   require 'rubygems'
                   require 'mysql'


### PR DESCRIPTION
- Changed mysql backend to hold YAML files instead of raw hashes.
- Support for other merge behaviours than native is added when :merge_behavior is defined in hiera.yaml and the 'deep_merge' ruby gem is installed. (support for future features) :sweat:
